### PR TITLE
Add support for new input system

### DIFF
--- a/Runtime/TimeManager.cs
+++ b/Runtime/TimeManager.cs
@@ -5,6 +5,11 @@ using UnityEngine.Events;
 using UnityEngine.UI;
 using TMPro;
 
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Controls;
+#endif
+
 namespace Kitbashery.Gameplay
 {
     /// <summary>
@@ -79,7 +84,7 @@ namespace Kitbashery.Gameplay
 
         private void Update()
         {
-            if(Input.GetKeyDown(togglePauseKey) == true)
+            if(isPauseKeyPressed())
             {
                 TogglePause();
             }
@@ -88,6 +93,17 @@ namespace Kitbashery.Gameplay
             {
                 CountFPS();
             }
+        }
+
+        private bool isPauseKeyPressed()
+        {
+            #if ENABLE_INPUT_SYSTEM
+                return ((KeyControl)Keyboard.current[togglePauseKey.ToString()]).wasPressedThisFrame;
+            #endif
+
+            #if ENABLE_LEGACY_INPUT_MANAGER
+                return Input.GetKeyDown(togglePauseKey) == true;
+            #endif
         }
 
         private IEnumerator ModifyTimeScale()

--- a/Runtime/kitbashery.game-kit.asmdef
+++ b/Runtime/kitbashery.game-kit.asmdef
@@ -2,7 +2,8 @@
     "name": "kitbashery.game-kit",
     "rootNamespace": "",
     "references": [
-        "GUID:6055be8ebefd69e48b49212b09b47b2f"
+        "GUID:6055be8ebefd69e48b49212b09b47b2f",
+        "GUID:75469ad4d38634e559750d17036d5f7c"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
Added support for Unitys new input system. Followed the example in their migration guide: https://docs.unity3d.com/Packages/com.unity.inputsystem@1.4/manual/Migration.html#unityengineinputgetkeyhttpsdocsunity3dcomscriptreferenceinputgetkeyhtml 